### PR TITLE
Remove unnecessary allocation of the args Vec

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,7 @@ extern "C" {
 }
 
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    let mut args: Vec<*mut c_char> = args.iter().map(|s| CString::new(s.as_str()).unwrap().into_raw()).collect();
+    let mut args: Vec<*mut c_char> = std::env::args().map(|s| CString::new(s.as_str()).unwrap().into_raw()).collect();
     unsafe {
         fluid_main(args.len() as i32, args.as_mut_ptr());
     }


### PR DESCRIPTION
`std::env::args()` already returns an iterator over `String`s, we don't
need to construct a `Vec<String>`.